### PR TITLE
fix/getWeChatDll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /GoWxDump.zip
 /decrypted
 /tmp
+.idea
 /*.txt

--- a/cmd_action.go
+++ b/cmd_action.go
@@ -16,22 +16,22 @@ func GetWeChatInfo() error {
 		return err
 	}
 	// 获取微信昵称
-	nickName, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.ModBaseAddr+uintptr(OffSetMap[version][0]), 100)
+	nickName, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.BaseOfDll+uintptr(OffSetMap[version][0]), 100)
 	if err != nil {
 		return err
 	}
 	// 获取微信账号
-	account, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.ModBaseAddr+uintptr(OffSetMap[version][1]), 100)
+	account, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.BaseOfDll+uintptr(OffSetMap[version][1]), 100)
 	if err != nil {
 		return err
 	}
 	// 获取微信手机号
-	mobile, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.ModBaseAddr+uintptr(OffSetMap[version][2]), 100)
+	mobile, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.BaseOfDll+uintptr(OffSetMap[version][2]), 100)
 	if err != nil {
 		return err
 	}
 	// 获取微信密钥
-	key, err := GetWeChatKey(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.ModBaseAddr+uintptr(OffSetMap[version][4]))
+	key, err := GetWeChatKey(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.BaseOfDll+uintptr(OffSetMap[version][4]))
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func DecryptCmd() {
 	dataDir := ""
 	if IsSupportAutoGetData(WeChatDataObject.Version) {
 		// 获取用户数据目录
-		dataDirName, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.ModBaseAddr+uintptr(OffSetMap[WeChatDataObject.Version][5]), 100)
+		dataDirName, err := GetWeChatData(WeChatDataObject.WeChatHandle, WeChatDataObject.WeChatWinModel.BaseOfDll+uintptr(OffSetMap[WeChatDataObject.Version][5]), 100)
 		if err != nil {
 			fmt.Println("GetWeChatDataDir error: ", err)
 			return

--- a/global.go
+++ b/global.go
@@ -25,7 +25,7 @@ type WeChatData struct {
 	Key            string
 	WeChatProcess  windows.ProcessEntry32
 	WeChatHandle   windows.Handle
-	WeChatWinModel windows.ModuleEntry32
+	WeChatWinModel *ModuleInfo
 }
 
 var PROCESS_ALL_ACCESS = uint32(

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	WeChatDataObject.WeChatHandle = wechatProcessHandle
 
 	// 获取微信模块
-	module, err := GetWeChatWinModule(process)
+	module, err := GetWeChatWinModule(wechatProcessHandle)
 	if err != nil {
 		fmt.Println("GetWeChatWinModule error: ", err)
 		return


### PR DESCRIPTION
<img width="870" alt="image" src="https://user-images.githubusercontent.com/81551286/231970454-bc5b91cf-9401-4627-b3f2-8b50f0cbf2c1.png">

indicates that only modules that are statically linked to the process are listed, i.e. those that are loaded when the process starts. It does not list dynamically loaded modules.
