### PR TITLE
feat: 无法获取注册表时自定义WeChat Files目录

### DIFF
--- a/wechat_util.go
+++ b/wechat_util.go
@@ -139,9 +139,6 @@ func GetWeChatFromRegistry() (string, error) {
 func GetWeChatDir() (string, error) {
 	msgDir := ""
 	wDir, err := GetWeChatFromRegistry()
-	if err != nil {
-		return "", err
-	}
 	// 如果wDir为MyDocument:
 	if wDir == "MyDocument:" {
 		// 获取%USERPROFILE%/Documents目录
@@ -158,7 +155,15 @@ func GetWeChatDir() (string, error) {
 	// 判断目录是否存在
 	_, err = os.Stat(msgDir)
 	if err != nil {
-		return "", err
+		// 手动输入目录
+		fmt.Print("输入WeChat Files所在目录路径（如d:\\documents）：")
+		fmt.Scanln(&msgDir)
+		msgDir = filepath.Join(msgDir, "WeChat Files")
+		// 判断目录是否存在
+		_, err = os.Stat(msgDir)
+		if err != nil {
+			return "", err
+		}
 	}
 	return msgDir, nil
 }


### PR DESCRIPTION
新版的微信不存在`HKEY_CURRENT_USER\Software\Tencent\WeChat\FileSavePath`注册表键值

同时，自定义存放WeChat Files位置时（包括我的文档更改过位置的情况，不能只使用`%USERPROFILE%/Documents`），程序无法正确获取到位置。

ps: 编译环境一直处理不好，CGO无法打开，这边就不编译了。